### PR TITLE
Completed basic operations for patient module

### DIFF
--- a/Dental-House/src/main/java/com/devbrain/dentahouse/DentalHouseApplication.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/DentalHouseApplication.java
@@ -2,8 +2,10 @@ package com.devbrain.dentahouse;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class DentalHouseApplication {
 
 	public static void main(String[] args) {

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/config/DoctorSetup.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/config/DoctorSetup.java
@@ -4,7 +4,6 @@ import com.devbrain.dentahouse.entity.Doctor;
 import com.devbrain.dentahouse.repository.DoctorRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/config/GenerateCustomId.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/config/GenerateCustomId.java
@@ -1,0 +1,14 @@
+package com.devbrain.dentahouse.config;
+
+import org.hibernate.annotations.IdGeneratorType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@IdGeneratorType(EntityIdGenerator.class)
+public @interface GenerateCustomId {
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/controller/PatientController.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/controller/PatientController.java
@@ -3,9 +3,12 @@ package com.devbrain.dentahouse.controller;
 import com.devbrain.dentahouse.requestdto.PatientRequest;
 import com.devbrain.dentahouse.responsedto.PatientResponse;
 import com.devbrain.dentahouse.service.PatientService;
+import com.devbrain.dentahouse.util.PageResponseStructure;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("${app.base_url}")
@@ -27,5 +30,10 @@ public class PatientController {
     @PutMapping("/patients/{patientId}")
     public ResponseEntity<PatientResponse> updatePatient(@RequestBody PatientRequest patientRequest, @PathVariable String patientId){
         return patientService.updatePatient(patientRequest, patientId);
+    }
+
+    @GetMapping("/patients")
+    public ResponseEntity<PageResponseStructure<List<PatientResponse>>> getAllPatients(@RequestParam int page, @RequestParam int size){
+        return patientService.getAllPatients(page, size);
     }
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/controller/PatientController.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/controller/PatientController.java
@@ -5,10 +5,7 @@ import com.devbrain.dentahouse.responsedto.PatientResponse;
 import com.devbrain.dentahouse.service.PatientService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("${app.base_url}")
@@ -20,5 +17,10 @@ public class PatientController {
     @PostMapping("/patients")
     public ResponseEntity<PatientResponse> addPatient(@RequestBody PatientRequest patientRequest){
         return patientService.addPatient(patientRequest);
+    }
+
+    @GetMapping("/patients/{patientId}")
+    public ResponseEntity<PatientResponse> getPatientById(@PathVariable String patientId){
+        return patientService.getPatient(patientId);
     }
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/controller/PatientController.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/controller/PatientController.java
@@ -1,0 +1,24 @@
+package com.devbrain.dentahouse.controller;
+
+import com.devbrain.dentahouse.requestdto.PatientRequest;
+import com.devbrain.dentahouse.responsedto.PatientResponse;
+import com.devbrain.dentahouse.service.PatientService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("${app.base_url}")
+@AllArgsConstructor
+public class PatientController {
+
+    private PatientService patientService;
+
+    @PostMapping("/patients")
+    public ResponseEntity<PatientResponse> addPatient(@RequestBody PatientRequest patientRequest){
+        return patientService.addPatient(patientRequest);
+    }
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/controller/PatientController.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/controller/PatientController.java
@@ -23,4 +23,9 @@ public class PatientController {
     public ResponseEntity<PatientResponse> getPatientById(@PathVariable String patientId){
         return patientService.getPatient(patientId);
     }
+
+    @PutMapping("/patients/{patientId}")
+    public ResponseEntity<PatientResponse> updatePatient(@RequestBody PatientRequest patientRequest, @PathVariable String patientId){
+        return patientService.updatePatient(patientRequest, patientId);
+    }
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/entity/Doctor.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/entity/Doctor.java
@@ -1,12 +1,8 @@
 package com.devbrain.dentahouse.entity;
 
-import com.devbrain.dentahouse.config.EntityIdGenerator;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.devbrain.dentahouse.config.GenerateCustomId;
+import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
 
 @Entity
 @Table(name = "doctor")
@@ -17,8 +13,7 @@ import org.hibernate.annotations.GenericGenerator;
 @NoArgsConstructor
 public class Doctor {
     @Id
-    @GeneratedValue(generator = "entity-id-generator")
-    @GenericGenerator(name = "entity-id-generator", type = EntityIdGenerator.class)
+    @GenerateCustomId
     private String doctorId;
     private String name;
     private long phoneNumber;

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/entity/Patient.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/entity/Patient.java
@@ -25,7 +25,9 @@ public class Patient {
     private String firstName;
     private String lastName;
     private LocalDate dateOfBirth;
+    @Enumerated(EnumType.STRING)
     private Gender gender;
+    @Enumerated(EnumType.STRING)
     private BloodGroup bloodGroup;
 
     // contact Info

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/entity/Patient.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/entity/Patient.java
@@ -1,0 +1,42 @@
+package com.devbrain.dentahouse.entity;
+
+import com.devbrain.dentahouse.config.GenerateCustomId;
+import com.devbrain.dentahouse.enums.BloodGroup;
+import com.devbrain.dentahouse.enums.Gender;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Table(name = "patient")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Patient {
+
+    // Basic Info
+    @Id
+    @GenerateCustomId
+    private String patientId;
+    private String firstName;
+    private String lastName;
+    private LocalDate dateOfBirth;
+    private Gender gender;
+    private BloodGroup bloodGroup;
+
+    // contact Info
+    private Long contactNumber;
+
+    // Other Info
+    @ElementCollection
+    @CollectionTable(name = "pre_medical_condition", joinColumns = @JoinColumn(name = "patient_id"))
+    @Column(name = "medial_condition")
+    private List<String> preMedicalConditions;
+
+    @Column(length = 2000)
+    private String note;
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/entity/Patient.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/entity/Patient.java
@@ -5,12 +5,15 @@ import com.devbrain.dentahouse.enums.BloodGroup;
 import com.devbrain.dentahouse.enums.Gender;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Entity
 @Table(name = "patient")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @Builder
@@ -34,14 +37,13 @@ public class Patient {
     private Long contactNumber;
 
     // Other Info
-    @ElementCollection
-    @CollectionTable(name = "pre_medical_condition", joinColumns = @JoinColumn(name = "patient_id"))
-    @Column(name = "medial_condition")
+    @Column(length = 2000)
     private List<String> preMedicalConditions;
-
     @Column(length = 2000)
     private String note;
 
+    // Auditing Info
+    @CreatedDate
     private LocalDate registeredDate;
     private LocalDate lastSittingDate;
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/enums/BloodGroup.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/enums/BloodGroup.java
@@ -1,0 +1,22 @@
+package com.devbrain.dentahouse.enums;
+
+public enum BloodGroup {
+    A_POSITIVE("A+"),
+    A_NEGATIVE("A-"),
+    B_POSITIVE("B+"),
+    B_NEGATIVE("B-"),
+    AB_POSITIVE("AB+"),
+    AB_NEGATIVE("AB-"),
+    O_POSITIVE("O+"),
+    O_NEGATIVE("O-");
+
+    private final String name;
+
+    BloodGroup(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/enums/Gender.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/enums/Gender.java
@@ -1,0 +1,5 @@
+package com.devbrain.dentahouse.enums;
+
+public enum Gender {
+    MALE, FEMALE, OTHER;
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/exceptionhandlers/PatientExceptionHandler.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/exceptionhandlers/PatientExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.devbrain.dentahouse.exceptionhandlers;
+
+import com.devbrain.dentahouse.exceptions.PatientNotFoundByIdException;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@AllArgsConstructor
+public class PatientExceptionHandler {
+
+    private final ErrorResponseBuilder errorResponseBuilder;
+
+    @ExceptionHandler(PatientNotFoundByIdException.class)
+    public ResponseEntity<ErrorResponse<String>> handlePatientNotFoundById(PatientNotFoundByIdException ex){
+        return errorResponseBuilder.withStringRootCause(HttpStatus.NOT_FOUND, ex.getMessage(), "Patient not present with the given patientId");
+    }
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/exceptions/PatientNotFoundByIdException.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/exceptions/PatientNotFoundByIdException.java
@@ -1,0 +1,10 @@
+package com.devbrain.dentahouse.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PatientNotFoundByIdException extends RuntimeException {
+    private final String message;
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/filters/FilterHelper.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/filters/FilterHelper.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.authentication.WebAuthenticationDetails;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 
 public class FilterHelper {
 
@@ -22,10 +23,10 @@ public class FilterHelper {
     }
 
     public static String extractCookie(String cookieName, Cookie[] cookies){
-        return Arrays.stream(cookies).filter(cookie -> cookie.getName().equals(cookieName))
+       List<String> cookieValues = Arrays.stream(cookies).filter(cookie -> cookie.getName().equals(cookieName))
                 .map(Cookie::getValue)
-                .toList()
-                .get(0);
+                .toList();
+        return cookieValues.isEmpty() ? null : cookieValues.get(0);
     }
 
     public static void setAuthentication(String username, HttpServletRequest request){

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtAuthFilter.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtAuthFilter.java
@@ -23,7 +23,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     private JwtService jwtService;
 
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("Authenticating Access Credentials..");

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtAuthFilter.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtAuthFilter.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.internal.FilterHelper;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -26,7 +27,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("Authenticating Access Credentials..");
-        String at = FilterHelper.extractCookie("at", request.getCookies());
+        String at = JwtAuthenticationHelper.extractCookie("at", request.getCookies());
 
         if(at != null){
             log.info("Access token extracted");
@@ -37,15 +38,15 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 username = jwtService.extractUsername(at);
             } catch (ExpiredJwtException ex){
                 log.info("Jwt token is expired");
-                FilterHelper.handleException(response, "Failed to authenticate");
+                JwtAuthenticationHelper.handleException(response, "Failed to authenticate");
             } catch (JwtException ex) {
                 log.info("Invalid Jwt token");
-                FilterHelper.handleException(response, "Authentication Failed | " + ex.getMessage());
+                JwtAuthenticationHelper.handleException(response, "Authentication Failed | " + ex.getMessage());
             }
 
             if(username != null){
                 log.info("username extracted");
-                FilterHelper.setAuthentication(username, request);
+                JwtAuthenticationHelper.setAuthentication(username, request);
             } else log.info("Username not found");
 
 

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtAuthenticationHelper.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtAuthenticationHelper.java
@@ -2,6 +2,8 @@ package com.devbrain.dentahouse.filters;
 
 import com.devbrain.dentahouse.util.SimpleResponseStructure;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtAuthenticationHelper.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtAuthenticationHelper.java
@@ -14,9 +14,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-public class FilterHelper {
+public class JwtAuthenticationHelper {
 
-    private FilterHelper() {
+    private JwtAuthenticationHelper() {
         /*
          * Created private constructor to avoid Instantiation of class
          * */

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtRefreshFilter.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/filters/JwtRefreshFilter.java
@@ -3,53 +3,47 @@ package com.devbrain.dentahouse.filters;
 import com.devbrain.dentahouse.security.JwtService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
-import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.internal.FilterHelper;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Arrays;
 
-@AllArgsConstructor
 @Slf4j
-public class JwtAuthFilter extends OncePerRequestFilter {
+@AllArgsConstructor
+public class JwtRefreshFilter extends OncePerRequestFilter {
 
-    private JwtService jwtService;
+    private final JwtService jwtService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         log.info("Authenticating Access Credentials..");
-        String at = JwtAuthenticationHelper.extractCookie("at", request.getCookies());
+        String rt = JwtAuthenticationHelper.extractCookie("rt", request.getCookies());
 
-        if(at != null){
-            log.info("Access token extracted");
+        if(rt != null){
+            log.info("Refresh Token extracted");
             String username = null;
 
             try{
-                username = jwtService.extractUsername(at);
+                username = jwtService.extractUsername(rt);
             } catch (ExpiredJwtException ex){
-                log.info("Access Token is expired");
+                log.info("Refresh Token is expired");
                 JwtAuthenticationHelper.handleException(response, "Failed to authenticate");
             } catch (JwtException ex) {
-                log.info("Invalid Access Token");
+                log.info("Invalid Refresh Token");
                 JwtAuthenticationHelper.handleException(response, "Authentication Failed | " + ex.getMessage());
             }
-
             if(username != null){
                 log.info("username extracted");
                 JwtAuthenticationHelper.setAuthentication(username, request);
             } else log.info("Username not found");
 
 
-        } else log.info("Access token not found");
+        } else log.info("Refresh token not found");
 
         filterChain.doFilter(request, response);
     }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/filters/LoginFilter.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/filters/LoginFilter.java
@@ -27,7 +27,7 @@ public class LoginFilter extends OncePerRequestFilter {
             log.info("Login request is authentic");
         }catch (UserAlreadyLoggedInException e){
             log.info("Failed to login, user already logged in");
-            FilterHelper.handleException(response, e.getMessage());
+            JwtAuthenticationHelper.handleException(response, e.getMessage());
         }
         filterChain.doFilter(request, response);
     }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/mapper/PatientMapper.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/mapper/PatientMapper.java
@@ -1,0 +1,40 @@
+package com.devbrain.dentahouse.mapper;
+
+import com.devbrain.dentahouse.entity.Patient;
+import com.devbrain.dentahouse.requestdto.PatientRequest;
+import com.devbrain.dentahouse.responsedto.PatientResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class PatientMapper {
+
+    public Patient mapToPatient(PatientRequest patientRequest, Patient patient) {
+        patient.setFirstName(patientRequest.getFirstName());
+        patient.setLastName(patientRequest.getLastName());
+        patient.setGender(patientRequest.getGender());
+        patient.setBloodGroup(patientRequest.getBloodGroup());
+        patient.setDateOfBirth(patientRequest.getDateOfBirth());
+        patient.setContactNumber(patientRequest.getContactNumber());
+        patient.setPreMedicalConditions(patientRequest.getPreMedicalConditions());
+        patient.setNote(patientRequest.getNote());
+        return patient;
+    }
+
+    public PatientResponse mapToPatientResponse(Patient patient) {
+        return PatientResponse.builder()
+                .patientId(patient.getPatientId())
+                .bloodGroup(patient.getBloodGroup())
+                .contactNumber(patient.getContactNumber())
+                .dateOfBirth(patient.getDateOfBirth())
+                .firstName(patient.getFirstName())
+                .gender(patient.getGender())
+                .lastName(patient.getLastName())
+                .lastSittingDate(patient.getLastSittingDate())
+                .note(patient.getNote())
+                .preMedicalConditions(patient.getPreMedicalConditions())
+                .registeredDate(patient.getRegisteredDate())
+                .build();
+    }
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/repository/PatientRepository.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/repository/PatientRepository.java
@@ -1,0 +1,7 @@
+package com.devbrain.dentahouse.repository;
+
+import com.devbrain.dentahouse.entity.Patient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PatientRepository extends JpaRepository<Patient, String> {
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/repository/PatientRepository.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/repository/PatientRepository.java
@@ -2,6 +2,7 @@ package com.devbrain.dentahouse.repository;
 
 import com.devbrain.dentahouse.entity.Patient;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface PatientRepository extends JpaRepository<Patient, String> {
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/requestdto/PatientRequest.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/requestdto/PatientRequest.java
@@ -1,4 +1,4 @@
-package com.devbrain.dentahouse.entity;
+package com.devbrain.dentahouse.requestdto;
 
 import com.devbrain.dentahouse.config.GenerateCustomId;
 import com.devbrain.dentahouse.enums.BloodGroup;
@@ -9,19 +9,14 @@ import lombok.*;
 import java.time.LocalDate;
 import java.util.List;
 
-@Entity
-@Table(name = "patient")
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Patient {
+public class PatientRequest {
 
     // Basic Info
-    @Id
-    @GenerateCustomId
-    private String patientId;
     private String firstName;
     private String lastName;
     private LocalDate dateOfBirth;
@@ -32,14 +27,6 @@ public class Patient {
     private Long contactNumber;
 
     // Other Info
-    @ElementCollection
-    @CollectionTable(name = "pre_medical_condition", joinColumns = @JoinColumn(name = "patient_id"))
-    @Column(name = "medial_condition")
     private List<String> preMedicalConditions;
-
-    @Column(length = 2000)
     private String note;
-
-    private LocalDate registeredDate;
-    private LocalDate lastSittingDate;
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/responsedto/PatientResponse.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/responsedto/PatientResponse.java
@@ -1,4 +1,4 @@
-package com.devbrain.dentahouse.entity;
+package com.devbrain.dentahouse.responsedto;
 
 import com.devbrain.dentahouse.config.GenerateCustomId;
 import com.devbrain.dentahouse.enums.BloodGroup;
@@ -9,18 +9,14 @@ import lombok.*;
 import java.time.LocalDate;
 import java.util.List;
 
-@Entity
-@Table(name = "patient")
 @Getter
 @Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Patient {
+public class PatientResponse {
 
     // Basic Info
-    @Id
-    @GenerateCustomId
     private String patientId;
     private String firstName;
     private String lastName;
@@ -32,14 +28,8 @@ public class Patient {
     private Long contactNumber;
 
     // Other Info
-    @ElementCollection
-    @CollectionTable(name = "pre_medical_condition", joinColumns = @JoinColumn(name = "patient_id"))
-    @Column(name = "medial_condition")
     private List<String> preMedicalConditions;
-
-    @Column(length = 2000)
     private String note;
-
     private LocalDate registeredDate;
     private LocalDate lastSittingDate;
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/security/SecurityConfig.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.devbrain.dentahouse.security;
 
 import com.devbrain.dentahouse.filters.JwtAuthFilter;
+import com.devbrain.dentahouse.filters.JwtRefreshFilter;
 import com.devbrain.dentahouse.filters.LoginFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -48,6 +49,17 @@ public class SecurityConfig {
 
     @Bean
     @Order(2)
+    SecurityFilterChain refreshFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity.csrf(AbstractHttpConfigurer::disable)
+                .securityMatchers(matcher -> matcher.requestMatchers(baseUrl+"/refresh-login/**"))
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(new JwtRefreshFilter(jwtService), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    @Order(3)
     SecurityFilterChain authenticationFilterChain(HttpSecurity httpSecurity) throws Exception {
         return httpSecurity.csrf(AbstractHttpConfigurer::disable)
                 .securityMatchers(matcher -> matcher.requestMatchers(baseUrl+"/**"))

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
@@ -32,4 +32,12 @@ public class PatientService {
                 .body(patientMapper.mapToPatientResponse(patient)))
                 .orElseThrow(() -> new PatientNotFoundByIdException("Failed to find the patient"));
     }
+
+    public ResponseEntity<PatientResponse> updatePatient(PatientRequest patientRequest, String patientId) {
+        return patientRepository.findById(patientId).map(patient -> {
+            patientMapper.mapToPatient(patientRequest, patient);
+            patient = patientRepository.save(patient);
+            return ResponseEntity.ok(patientMapper.mapToPatientResponse(patient));
+        }).orElseThrow(() -> new PatientNotFoundByIdException("Failed to update the patient"));
+    }
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
@@ -6,12 +6,14 @@ import com.devbrain.dentahouse.mapper.PatientMapper;
 import com.devbrain.dentahouse.repository.PatientRepository;
 import com.devbrain.dentahouse.requestdto.PatientRequest;
 import com.devbrain.dentahouse.responsedto.PatientResponse;
+import com.devbrain.dentahouse.util.PageResponseStructure;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @AllArgsConstructor
@@ -22,7 +24,7 @@ public class PatientService {
 
     public ResponseEntity<PatientResponse> addPatient(PatientRequest patientRequest) {
         Patient patient = patientMapper.mapToPatient(patientRequest, new Patient());
-        patient.setRegisteredDate(LocalDate.now());
+//        patient.setRegisteredDate(LocalDate.now());
         patient = patientRepository.save(patient);
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -31,8 +33,8 @@ public class PatientService {
 
     public ResponseEntity<PatientResponse> getPatient(String patientId) {
         return patientRepository.findById(patientId).map(patient -> ResponseEntity
-                .status(HttpStatus.FOUND)
-                .body(patientMapper.mapToPatientResponse(patient)))
+                        .status(HttpStatus.FOUND)
+                        .body(patientMapper.mapToPatientResponse(patient)))
                 .orElseThrow(() -> new PatientNotFoundByIdException("Failed to find the patient"));
     }
 
@@ -42,5 +44,24 @@ public class PatientService {
             patient = patientRepository.save(patient);
             return ResponseEntity.ok(patientMapper.mapToPatientResponse(patient));
         }).orElseThrow(() -> new PatientNotFoundByIdException("Failed to update the patient"));
+    }
+
+    public ResponseEntity<PageResponseStructure<List<PatientResponse>>> getAllPatients(int page, int size) {
+        List<PatientResponse> patients = patientRepository.findAll(PageRequest.of(page - 1, size))
+                .map(patientMapper::mapToPatientResponse)
+                .toList();
+
+        long countOfPatients = patientRepository.count();
+        long totalPages = countOfPatients / size;
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .body(new PageResponseStructure<List<PatientResponse>>()
+                        .setList(patients)
+                        .setPage(page)
+                        /*
+                         * making sure that total pages returned is never zero
+                         * if there are at least one patient int the database
+                         */
+                        .setTotalPages(totalPages == 0 && countOfPatients > 0 ? 1 : totalPages)
+                        .setTotalAvailableRecords(countOfPatients));
     }
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
@@ -1,6 +1,7 @@
 package com.devbrain.dentahouse.service;
 
 import com.devbrain.dentahouse.entity.Patient;
+import com.devbrain.dentahouse.exceptions.PatientNotFoundByIdException;
 import com.devbrain.dentahouse.mapper.PatientMapper;
 import com.devbrain.dentahouse.repository.PatientRepository;
 import com.devbrain.dentahouse.requestdto.PatientRequest;
@@ -23,5 +24,12 @@ public class PatientService {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(patientMapper.mapToPatientResponse(patient));
+    }
+
+    public ResponseEntity<PatientResponse> getPatient(String patientId) {
+        return patientRepository.findById(patientId).map(patient -> ResponseEntity
+                .status(HttpStatus.FOUND)
+                .body(patientMapper.mapToPatientResponse(patient)))
+                .orElseThrow(() -> new PatientNotFoundByIdException("Failed to find the patient"));
     }
 }

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
 @AllArgsConstructor
 public class PatientService {
@@ -20,6 +22,7 @@ public class PatientService {
 
     public ResponseEntity<PatientResponse> addPatient(PatientRequest patientRequest) {
         Patient patient = patientMapper.mapToPatient(patientRequest, new Patient());
+        patient.setRegisteredDate(LocalDate.now());
         patient = patientRepository.save(patient);
 
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/service/PatientService.java
@@ -1,0 +1,27 @@
+package com.devbrain.dentahouse.service;
+
+import com.devbrain.dentahouse.entity.Patient;
+import com.devbrain.dentahouse.mapper.PatientMapper;
+import com.devbrain.dentahouse.repository.PatientRepository;
+import com.devbrain.dentahouse.requestdto.PatientRequest;
+import com.devbrain.dentahouse.responsedto.PatientResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class PatientService {
+
+    private final PatientRepository patientRepository;
+    private final PatientMapper patientMapper;
+
+    public ResponseEntity<PatientResponse> addPatient(PatientRequest patientRequest) {
+        Patient patient = patientMapper.mapToPatient(patientRequest, new Patient());
+        patient = patientRepository.save(patient);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(patientMapper.mapToPatientResponse(patient));
+    }
+}

--- a/Dental-House/src/main/java/com/devbrain/dentahouse/util/PageResponseStructure.java
+++ b/Dental-House/src/main/java/com/devbrain/dentahouse/util/PageResponseStructure.java
@@ -1,0 +1,31 @@
+package com.devbrain.dentahouse.util;
+
+import lombok.Getter;
+
+@Getter
+public class PageResponseStructure<T> {
+    private T list;
+    private int page;
+    private long totalPages;
+    private long totalAvailableRecords;
+
+    public PageResponseStructure<T> setList(T list) {
+        this.list = list;
+        return this;
+    }
+
+    public PageResponseStructure<T> setPage(int page) {
+        this.page = page;
+        return this;
+    }
+
+    public PageResponseStructure<T> setTotalPages(long totalPages) {
+        this.totalPages = totalPages;
+        return this;
+    }
+
+    public PageResponseStructure<T> setTotalAvailableRecords(long totalAvailableRecords) {
+        this.totalAvailableRecords = totalAvailableRecords;
+        return this;
+    }
+}


### PR DESCRIPTION
# Features
- Add Patient endpoint
- Find patient By ID endpoint
- Update patient endpoint
- find all patient endpoint

## Highlights
- Used pagination to find all patients
- Created a dedicated helper DTO class structuring the page responses supportive fields such as `page`, `totalPages`, and `totalAvailableRecords`.
- Added new Security Filter Chain with new Refresh Filter at order 2 to authenticate the refresh-login requests

# Issues Solved
- The `@GenericGenerator` to autogenerate the custom primary key values was deprecated for spring 3.3 and hibernate 6.5, **solved by** creating a custom Id Generator annotation `@GenerateCustomId` to autogenerate the primary key values.